### PR TITLE
Adjust Jupyter for Web App

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,17 @@ endif
 .PHONY: __bake
 __bake: upload-code upload-data upload-notebooks
 	echo "#!/usr/bin/env bash" > jupyter.sh
-	echo "jupyter notebook --no-browser --ip=0.0.0.0 --allow-root \
-	    --NotebookApp.token= --notebook-dir=/project/notebooks" >> jupyter.sh
+	echo "jupyter notebook \
+            --no-browser \
+            --ip=0.0.0.0 \
+            --allow-root \
+	    --NotebookApp.token= \
+            --NotebookApp.default_url=/project/notebooks/demo.ipynb\
+            --NotebookApp.shutdown_no_activity_timeout=10800 \
+            --MappingKernelManager.cull_idle_timeout=10800 \
+            --MappingKernelManager.cull_interval=60 \
+            --Application.log_level=DEBUG \
+" >> jupyter.sh
 	$(NEURO) cp jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
 	    "bash -c 'mkdir -p /project; cp -R -T $(PROJECT_PATH_ENV) /project'"

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help:
 
 .PHONY: setup
 setup: ### Setup remote environment
-	#$(NEURO) kill $(SETUP_JOB) >/dev/null 2>&1 || :
+	$(NEURO) kill $(SETUP_JOB) >/dev/null 2>&1 || :
 	$(NEURO) run \
 		--name $(SETUP_JOB) \
 		--preset cpu-small \
@@ -85,13 +85,15 @@ __bake: upload-code upload-data upload-notebooks
             --ip=0.0.0.0 \
             --allow-root \
             --NotebookApp.token= \
-            --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb\
+            --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb \
             --NotebookApp.shutdown_no_activity_timeout=7200 \
             --MappingKernelManager.cull_idle_timeout=7200 \
 " >> /tmp/jupyter.sh
 	$(NEURO) cp /tmp/jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
 	    "bash -c 'mkdir -p /project; cp -R -T $(PROJECT_PATH_ENV) /project'"
+	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
+           "jupyter trust /project/notebooks/demo.ipynb"
 
 
 ##### STORAGE #####

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ endif
 
 .PHONY: __bake
 __bake: upload-code upload-data upload-notebooks
-	echo "#!/usr/bin/env bash" > jupyter.sh
+	echo "#!/usr/bin/env bash" > /tmp/jupyter.sh
 	echo "jupyter notebook \
             --no-browser \
             --ip=0.0.0.0 \
@@ -88,8 +88,8 @@ __bake: upload-code upload-data upload-notebooks
             --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb\
             --NotebookApp.shutdown_no_activity_timeout=10800 \
             --MappingKernelManager.cull_idle_timeout=10800 \
-" >> jupyter.sh
-	$(NEURO) cp jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
+" >> /tmp/jupyter.sh
+	$(NEURO) cp /tmp/jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
 	    "bash -c 'mkdir -p /project; cp -R -T $(PROJECT_PATH_ENV) /project'"
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ __bake: upload-code upload-data upload-notebooks
             --NotebookApp.default_url=/project/notebooks/demo.ipynb\
             --NotebookApp.shutdown_no_activity_timeout=10800 \
             --MappingKernelManager.cull_idle_timeout=10800 \
-            --MappingKernelManager.cull_interval=60 \
 " >> jupyter.sh
 	$(NEURO) cp jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ __bake: upload-code upload-data upload-notebooks
             --ip=0.0.0.0 \
             --allow-root \
             --NotebookApp.token= \
-            --NotebookApp.default_url=/project/notebooks/demo.ipynb\
+            --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb\
             --NotebookApp.shutdown_no_activity_timeout=10800 \
             --MappingKernelManager.cull_idle_timeout=10800 \
 " >> jupyter.sh

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ __bake: upload-code upload-data upload-notebooks
             --NotebookApp.shutdown_no_activity_timeout=10800 \
             --MappingKernelManager.cull_idle_timeout=10800 \
             --MappingKernelManager.cull_interval=60 \
-            --Application.log_level=DEBUG \
 " >> jupyter.sh
 	$(NEURO) cp jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ __bake: upload-code upload-data upload-notebooks
             --no-browser \
             --ip=0.0.0.0 \
             --allow-root \
-	    --NotebookApp.token= \
+            --NotebookApp.token= \
             --NotebookApp.default_url=/project/notebooks/demo.ipynb\
             --NotebookApp.shutdown_no_activity_timeout=10800 \
             --MappingKernelManager.cull_idle_timeout=10800 \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help:
 
 .PHONY: setup
 setup: ### Setup remote environment
-	$(NEURO) kill $(SETUP_JOB) >/dev/null 2>&1 || :
+	#$(NEURO) kill $(SETUP_JOB) >/dev/null 2>&1 || :
 	$(NEURO) run \
 		--name $(SETUP_JOB) \
 		--preset cpu-small \
@@ -86,8 +86,8 @@ __bake: upload-code upload-data upload-notebooks
             --allow-root \
             --NotebookApp.token= \
             --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb\
-            --NotebookApp.shutdown_no_activity_timeout=10800 \
-            --MappingKernelManager.cull_idle_timeout=10800 \
+            --NotebookApp.shutdown_no_activity_timeout=7200 \
+            --MappingKernelManager.cull_idle_timeout=7200 \
 " >> /tmp/jupyter.sh
 	$(NEURO) cp /tmp/jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \

--- a/jupyter.sh
+++ b/jupyter.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+jupyter notebook --no-browser --ip=0.0.0.0 --allow-root     --NotebookApp.token= --notebook-dir=/project/notebooks             --NotebookApp.default_url=/project/notebooks/demo.ipynb

--- a/jupyter.sh
+++ b/jupyter.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-jupyter notebook --no-browser --ip=0.0.0.0 --allow-root     --NotebookApp.token= --notebook-dir=/project/notebooks             --NotebookApp.default_url=/project/notebooks/demo.ipynb

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -9,6 +9,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Uncomment command below to kill current job:\n",
+    "#!neuro kill $(hostname)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
1. Add the command to kill self as the first cell of notebook (commented)
- For now won't work as the version of `neuromation` in base image is outdated (raises unicode error). Will be fixed automatically with the new release of base image.
2. When the recipe runs as web shell, adjust its parameters:
- Open the notebook right away, without any additional click (`NotebookApp.default_url`)
- Set up 2 hours inactivity timeout for the notebook (`shutdown_no_activity_timeout` and `cull_idle_timeout`)
- minor: don't create `jupyter.sh` locally but create `/tmp/jupyter.sh`, in order not to mess the repo up accidentally
3. Trust the notebook (`jupyter trust demo.ipynb`)