### PR TITLE
Use /project-local instead of /project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
                 CUSTOM_ENV_NAME=$IMAGE_URI \
                 PROJECT_PATH_STORAGE=storage:build-$CIRCLE_BUILD_NUM
             neuro pull $IMAGE_URI
-            docker tag $IMAGE_REF $IMAGE_NAME:latest
+            docker tag $IMAGE_REF $IMAGE_NAME:debug
       - docker/check
       - docker/push:
           image: neuromation/ml-recipe-object-detection

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,11 @@ jobs:
                 CUSTOM_ENV_NAME=$IMAGE_URI \
                 PROJECT_PATH_STORAGE=storage:build-$CIRCLE_BUILD_NUM
             neuro pull $IMAGE_URI
-            docker tag $IMAGE_REF $IMAGE_NAME:$CIRCLE_TAG
             docker tag $IMAGE_REF $IMAGE_NAME:latest
       - docker/check
       - docker/push:
           image: neuromation/ml-recipe-object-detection
-          tag: $CIRCLE_TAG,latest
+          tag: debug
 
 
 workflows:
@@ -52,7 +51,7 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: /.*/
+              ignore: CHANGEME
             tags:
               only:
                 - /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,12 @@ jobs:
                 CUSTOM_ENV_NAME=$IMAGE_URI \
                 PROJECT_PATH_STORAGE=storage:build-$CIRCLE_BUILD_NUM
             neuro pull $IMAGE_URI
-            docker tag $IMAGE_REF $IMAGE_NAME:debug
+            docker tag $IMAGE_REF $IMAGE_NAME:$CIRCLE_TAG
+            docker tag $IMAGE_REF $IMAGE_NAME:latest
       - docker/check
       - docker/push:
           image: neuromation/ml-recipe-object-detection
-          tag: debug
+          tag: $CIRCLE_TAG,latest
 
 
 workflows:
@@ -51,7 +52,7 @@ workflows:
       - build:
           filters:
             branches:
-              ignore: CHANGEME
+              ignore: /.*/
             tags:
               only:
                 - /.*/

--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,15 @@ __bake: upload-code upload-data upload-notebooks
             --ip=0.0.0.0 \
             --allow-root \
             --NotebookApp.token= \
-            --NotebookApp.default_url=/notebooks/project/notebooks/demo.ipynb \
+            --NotebookApp.default_url=/notebooks/project-local/notebooks/demo.ipynb \
             --NotebookApp.shutdown_no_activity_timeout=7200 \
             --MappingKernelManager.cull_idle_timeout=7200 \
 " >> /tmp/jupyter.sh
 	$(NEURO) cp /tmp/jupyter.sh $(PROJECT_PATH_STORAGE)/jupyter.sh
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
-	    "bash -c 'mkdir -p /project; cp -R -T $(PROJECT_PATH_ENV) /project'"
+	    "bash -c 'mkdir -p /project-local; cp -R -T $(PROJECT_PATH_ENV) /project-local'"
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
-           "jupyter trust /project/notebooks/demo.ipynb"
+           "jupyter trust /project-local/notebooks/demo.ipynb"
 
 
 ##### STORAGE #####

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ __bake: upload-code upload-data upload-notebooks
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) \
            "jupyter trust /project-local/notebooks/demo.ipynb"
 
-
 ##### STORAGE #####
 
 .PHONY: upload-code


### PR DESCRIPTION
Since https://github.com/neuromation/cookiecutter-neuro-project/pull/354, `/project` is the mountpoint for the project for all Template-generated projects. So we need to bake into `/project-local`.

https://circleci.com/gh/neuromation/ml-recipe-object-detection/17
https://hub.docker.com/layers/neuromation/ml-recipe-object-detection/debug/images/sha256-f69d6faae14b2aca3a35b5d40848e7f59735c6822d0e8ba84c4877b4e917570c